### PR TITLE
Use external media directory for sessions

### DIFF
--- a/smali_classes2/com/citnow/file_management/session/SessionFolderManagerImpl$listAllSessions$2.smali
+++ b/smali_classes2/com/citnow/file_management/session/SessionFolderManagerImpl$listAllSessions$2.smali
@@ -185,11 +185,7 @@
     .line 34
     iget-object p0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl$listAllSessions$2;->this$0:Lcom/citnow/file_management/session/SessionFolderManagerImpl;
 
-    invoke-virtual {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->getContext()Landroid/content/Context;
-
-    move-result-object p0
-
-    invoke-virtual {p0}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object p0
 

--- a/smali_classes2/com/citnow/file_management/session/SessionFolderManagerImpl$migrateOldSessions$2.smali
+++ b/smali_classes2/com/citnow/file_management/session/SessionFolderManagerImpl$migrateOldSessions$2.smali
@@ -224,11 +224,7 @@
 
     iget-object v0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl$migrateOldSessions$2;->this$0:Lcom/citnow/file_management/session/SessionFolderManagerImpl;
 
-    invoke-virtual {v0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->getContext()Landroid/content/Context;
-
-    move-result-object v0
-
-    invoke-virtual {v0}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {v0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object v0
 
@@ -279,11 +275,7 @@
     :cond_1
     iget-object v0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl$migrateOldSessions$2;->this$0:Lcom/citnow/file_management/session/SessionFolderManagerImpl;
 
-    invoke-virtual {v0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->getContext()Landroid/content/Context;
-
-    move-result-object v0
-
-    invoke-virtual {v0}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {v0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object v0
 

--- a/smali_classes2/com/citnow/file_management/session/SessionFolderManagerImpl.smali
+++ b/smali_classes2/com/citnow/file_management/session/SessionFolderManagerImpl.smali
@@ -122,6 +122,38 @@
     return-void
 .end method
 
+.method private final baseMediaDir()Ljava/io/File;
+    .locals 3
+
+    iget-object v0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
+
+    invoke-virtual {v0}, Landroid/content/Context;->getExternalMediaDirs()[Ljava/io/File;
+
+    move-result-object v1
+
+    const/4 v2, 0x0
+
+    if-eqz v1, :cond_0
+
+    array-length v0, v1
+
+    if-lez v0, :cond_0
+
+    aget-object v0, v1, v2
+
+    if-nez v0, :cond_1
+
+    :cond_0
+    iget-object v0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
+
+    invoke-virtual {v0}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+
+    move-result-object v0
+
+    :cond_1
+    return-object v0
+.end method
+
 .method private final copyFolder(Ljava/io/File;Ljava/io/File;)V
     .locals 8
 
@@ -401,10 +433,7 @@
 
     .line 90
     new-instance v0, Ljava/io/File;
-
-    iget-object v1, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
-
-    invoke-virtual {v1}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object v1
 
@@ -424,7 +453,7 @@
     if-nez p0, :cond_0
 
     .line 92
-    invoke-virtual {v0}, Ljava/io/File;->mkdir()Z
+    invoke-virtual {v0}, Ljava/io/File;->mkdirs()Z
 
     move-result p0
 
@@ -447,9 +476,7 @@
     .line 20
     new-instance v0, Ljava/io/File;
 
-    iget-object v1, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
-
-    invoke-virtual {v1}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object v1
 
@@ -469,7 +496,7 @@
     if-nez p0, :cond_0
 
     .line 22
-    invoke-virtual {v0}, Ljava/io/File;->mkdir()Z
+    invoke-virtual {v0}, Ljava/io/File;->mkdirs()Z
 
     .line 25
     :cond_0
@@ -485,7 +512,7 @@
     if-nez p1, :cond_1
 
     .line 27
-    invoke-virtual {p0}, Ljava/io/File;->mkdir()Z
+    invoke-virtual {p0}, Ljava/io/File;->mkdirs()Z
 
     move-result p0
 
@@ -506,9 +533,7 @@
     invoke-static {p1, v0}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullParameter(Ljava/lang/Object;Ljava/lang/String;)V
 
     .line 107
-    iget-object p0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
-
-    invoke-virtual {p0}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object p0
 
@@ -719,9 +744,7 @@
     .line 99
     new-instance v0, Ljava/io/File;
 
-    iget-object p0, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
-
-    invoke-virtual {p0}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object p0
 
@@ -771,9 +794,7 @@
 
     new-instance v1, Ljava/io/File;
 
-    iget-object v2, p0, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->context:Landroid/content/Context;
-
-    invoke-virtual {v2}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+    invoke-direct {p0}, Lcom/citnow/file_management/session/SessionFolderManagerImpl;->baseMediaDir()Ljava/io/File;
 
     move-result-object v2
 


### PR DESCRIPTION
## Summary
- centralize media root with `baseMediaDir` selecting external media storage with internal fallback
- ensure session and LID folders are created under external media dir
- update session listing/migration helpers to use new base path

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e49790b18832fbef5dbc091b5d53f