### PR TITLE
Handle Room database on external storage when available

### DIFF
--- a/smali_classes2/com/citnow/di/DataModule.smali
+++ b/smali_classes2/com/citnow/di/DataModule.smali
@@ -510,7 +510,7 @@
 .end method
 
 .method public final provideRoomDatabase(Landroid/content/Context;Lcom/citnow/security/Security;)Lcom/citnow/data/room/database/AppDatabase;
-    .locals 2
+    .locals 3
     .param p1    # Landroid/content/Context;
         .annotation runtime Ldagger/hilt/android/qualifiers/ApplicationContext;
         .end annotation
@@ -541,13 +541,53 @@
     .line 210
     const-class p2, Lcom/citnow/data/room/database/AppDatabase;
 
+    const/4 v0, 0x0
+
     .line 211
+    invoke-virtual {p1, v0}, Landroid/content/Context;->getExternalFilesDir(Ljava/lang/String;)Ljava/io/File;
+
+    move-result-object v0
+
+    if-eqz v0, :cond_0
+
+    invoke-virtual {v0}, Ljava/io/File;->getParentFile()Ljava/io/File;
+
+    move-result-object v0
+
+    const-string v1, "databases/citNow_database.db"
+
+    new-instance v2, Ljava/io/File;
+
+    invoke-direct {v2, v0, v1}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    invoke-virtual {v2}, Ljava/io/File;->getParentFile()Ljava/io/File;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Ljava/io/File;->mkdirs()Z
+
+    move-result v0
+
+    invoke-virtual {v2}, Ljava/io/File;->getAbsolutePath()Ljava/lang/String;
+
+    move-result-object v0
+
+    .line 208
+    invoke-static {p1, p2, v0}, Landroidx/room/Room;->databaseBuilder(Landroid/content/Context;Ljava/lang/Class;Ljava/lang/String;)Landroidx/room/RoomDatabase$Builder;
+
+    move-result-object p1
+
+    goto :cond_1
+
+    :cond_0
     const-string v0, "citNow_database.db"
 
     .line 208
     invoke-static {p1, p2, v0}, Landroidx/room/Room;->databaseBuilder(Landroid/content/Context;Ljava/lang/Class;Ljava/lang/String;)Landroidx/room/RoomDatabase$Builder;
 
     move-result-object p1
+
+    :cond_1
 
     const/16 p2, 0x8
 


### PR DESCRIPTION
## Summary
- Allow Room database to reside on external storage when available
- Retain internal storage path as fallback

## Testing
- `./gradlew test` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688e6d4ab5d8832fb9d1304cb8c2aa19