### PR TITLE
Add clipboard copy for room passphrase

### DIFF
--- a/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
@@ -42,6 +42,15 @@
     invoke-static {v0, v1}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V
     invoke-static {v0}, Lcom/citnow/ExtensionsKt;->toHex([B)Ljava/lang/String;
     move-result-object v0
+    new-instance v1, Ljava/lang/StringBuilder;
+    invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
+    const-string v2, "x'"
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+    invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+    const/16 v2, 0x27
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+    move-result-object v0
     iget-object v1, p0, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->context:Landroid/content/Context;
     const-string v2, "clipboard"
     invoke-virtual {v1, v2}, Landroid/content/Context;->getSystemService(Ljava/lang/String;)Ljava/lang/Object;

--- a/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
@@ -1,0 +1,48 @@
+.class final Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;
+.super Ljava/lang/Object;
+.source "SettingsViewScreen.kt"
+
+# interfaces
+.implements Lkotlin/jvm/functions/Function0;
+
+# instance fields
+.field private final context:Landroid/content/Context;
+
+# direct methods
+.method public constructor <init>(Landroid/content/Context;)V
+    .locals 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+    iput-object p1, p0, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->context:Landroid/content/Context;
+    return-void
+.end method
+
+# virtual methods
+.method public bridge synthetic invoke()Ljava/lang/Object;
+    .locals 1
+    invoke-virtual {p0}, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->invoke()V
+    sget-object v0, Lkotlin/Unit;->INSTANCE:Lkotlin/Unit;
+    return-object v0
+.end method
+
+.method public final invoke()V
+    .locals 5
+    iget-object v0, p0, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->context:Landroid/content/Context;
+    const-string v1, "citNow-prefs"
+    const/4 v2, 0x0
+    invoke-virtual {v0, v1, v2}, Landroid/content/Context;->getSharedPreferences(Ljava/lang/String;I)Landroid/content/SharedPreferences;
+    move-result-object v0
+    const-string v1, "citNow-room-pass-phrase"
+    const-string v2, ""
+    invoke-interface {v0, v1, v2}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v0
+    iget-object v1, p0, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->context:Landroid/content/Context;
+    const-string v2, "clipboard"
+    invoke-virtual {v1, v2}, Landroid/content/Context;->getSystemService(Ljava/lang/String;)Ljava/lang/Object;
+    move-result-object v1
+    check-cast v1, Landroid/content/ClipboardManager;
+    const-string v2, "DB Key"
+    invoke-static {v2, v0}, Landroid/content/ClipData;->newPlainText(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Landroid/content/ClipData;
+    move-result-object v0
+    invoke-virtual {v1, v0}, Landroid/content/ClipboardManager;->setPrimaryClip(Landroid/content/ClipData;)V
+    return-void
+.end method

--- a/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
@@ -35,6 +35,13 @@
     const-string v2, ""
     invoke-interface {v0, v1, v2}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
     move-result-object v0
+    sget-object v1, Lkotlin/text/Charsets;->ISO_8859_1:Ljava/nio/charset/Charset;
+    invoke-virtual {v0, v1}, Ljava/lang/String;->getBytes(Ljava/nio/charset/Charset;)[B
+    move-result-object v0
+    const-string v1, "getBytes(...)"
+    invoke-static {v0, v1}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V
+    invoke-static {v0}, Lcom/citnow/ExtensionsKt;->toHex([B)Ljava/lang/String;
+    move-result-object v0
     iget-object v1, p0, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->context:Landroid/content/Context;
     const-string v2, "clipboard"
     invoke-virtual {v1, v2}, Landroid/content/Context;->getSystemService(Ljava/lang/String;)Ljava/lang/Object;

--- a/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback.smali
@@ -42,15 +42,6 @@
     invoke-static {v0, v1}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V
     invoke-static {v0}, Lcom/citnow/ExtensionsKt;->toHex([B)Ljava/lang/String;
     move-result-object v0
-    new-instance v1, Ljava/lang/StringBuilder;
-    invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
-    const-string v2, "x'"
-    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-    invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-    const/16 v2, 0x27
-    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
-    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
-    move-result-object v0
     iget-object v1, p0, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;->context:Landroid/content/Context;
     const-string v2, "clipboard"
     invoke-virtual {v1, v2}, Landroid/content/Context;->getSystemService(Ljava/lang/String;)Ljava/lang/Object;

--- a/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
@@ -84,6 +84,15 @@
     invoke-static {v1, v4}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V
     invoke-static {v1}, Lcom/citnow/ExtensionsKt;->toHex([B)Ljava/lang/String;
     move-result-object v1
+    new-instance v4, Ljava/lang/StringBuilder;
+    invoke-direct {v4}, Ljava/lang/StringBuilder;-><init>()V
+    const-string v5, "x'"
+    invoke-virtual {v4, v5}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+    invoke-virtual {v4, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+    const/16 v5, 0x27
+    invoke-virtual {v4, v5}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+    invoke-virtual {v4}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+    move-result-object v1
     const/4 v4, 0x0
     invoke-static {v1, v4, v2, p1, v3}, Lcom/citnow/android_refactored/settings_view/ComponentsKt;->SettingInfoItem(Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
     const-string v1, "Button 3"

--- a/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
@@ -84,15 +84,6 @@
     invoke-static {v1, v4}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V
     invoke-static {v1}, Lcom/citnow/ExtensionsKt;->toHex([B)Ljava/lang/String;
     move-result-object v1
-    new-instance v4, Ljava/lang/StringBuilder;
-    invoke-direct {v4}, Ljava/lang/StringBuilder;-><init>()V
-    const-string v5, "x'"
-    invoke-virtual {v4, v5}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-    invoke-virtual {v4, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-    const/16 v5, 0x27
-    invoke-virtual {v4, v5}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
-    invoke-virtual {v4}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
-    move-result-object v1
     const/4 v4, 0x0
     invoke-static {v1, v4, v2, p1, v3}, Lcom/citnow/android_refactored/settings_view/ComponentsKt;->SettingInfoItem(Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
     const-string v1, "Button 3"

--- a/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
@@ -65,8 +65,9 @@
     const/16 v3, 0x30
     const/4 v4, 0x1
     invoke-static {v1, v4, v2, p1, v3}, Lcom/citnow/android_refactored/settings_view/ComponentsKt;->SettingInfoItem(Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-    const-string v1, "Button 2"
-    sget-object v2, Lcom/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7$1;->INSTANCE:Lcom/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7$1;
+    const-string v1, "Copy DB Key"
+    new-instance v2, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;
+    invoke-direct {v2, v0}, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;-><init>(Landroid/content/Context;)V
     invoke-static {v1, v4, v2, p1, v3}, Lcom/citnow/android_refactored/settings_view/ComponentsKt;->SettingInfoItem(Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
     const-string v1, "Button 3"
     sget-object v2, Lcom/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7$1;->INSTANCE:Lcom/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7$1;

--- a/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
+++ b/smali_classes5/com/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7.smali
@@ -69,6 +69,23 @@
     new-instance v2, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;
     invoke-direct {v2, v0}, Lcom/citnow/android_refactored/settings_view/CopyRoomPassphraseCallback;-><init>(Landroid/content/Context;)V
     invoke-static {v1, v4, v2, p1, v3}, Lcom/citnow/android_refactored/settings_view/ComponentsKt;->SettingInfoItem(Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+    const-string v1, "citNow-prefs"
+    const/4 v4, 0x0
+    invoke-virtual {v0, v1, v4}, Landroid/content/Context;->getSharedPreferences(Ljava/lang/String;I)Landroid/content/SharedPreferences;
+    move-result-object v1
+    const-string v4, "citNow-room-pass-phrase"
+    const-string v5, ""
+    invoke-interface {v1, v4, v5}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v1
+    sget-object v4, Lkotlin/text/Charsets;->ISO_8859_1:Ljava/nio/charset/Charset;
+    invoke-virtual {v1, v4}, Ljava/lang/String;->getBytes(Ljava/nio/charset/Charset;)[B
+    move-result-object v1
+    const-string v4, "getBytes(...)"
+    invoke-static {v1, v4}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V
+    invoke-static {v1}, Lcom/citnow/ExtensionsKt;->toHex([B)Ljava/lang/String;
+    move-result-object v1
+    const/4 v4, 0x0
+    invoke-static {v1, v4, v2, p1, v3}, Lcom/citnow/android_refactored/settings_view/ComponentsKt;->SettingInfoItem(Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
     const-string v1, "Button 3"
     sget-object v2, Lcom/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7$1;->INSTANCE:Lcom/citnow/android_refactored/settings_view/SettingsViewScreenKt$SettingsViewScreen$10$1$1$1$1$7$1;
     const/4 v4, 0x0


### PR DESCRIPTION
## Summary
- add settings callback to copy citNow room passphrase to clipboard
- rename settings button to "Copy DB Key" and wire it to new callback

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f0ca6c81c832f91906381426c55b9